### PR TITLE
chore(vercel): redirect to /ionicons when visiting vercel links 

### DIFF
--- a/src/components/notfound-page/notfound-page.scss
+++ b/src/components/notfound-page/notfound-page.scss
@@ -4,9 +4,14 @@ notfound-page {
 
   h1 {
     max-width: 500px;
+    margin: 0 auto;
   }
 
   a {
     font-weight: 600;
+  }
+
+  p {
+    margin-bottom: 100px;
   }
 }

--- a/src/components/notfound-page/notfound-page.tsx
+++ b/src/components/notfound-page/notfound-page.tsx
@@ -12,7 +12,7 @@ export class NotFoundPage {
       <main>
         <ResponsiveContainer>
           <h1>Oops! We can't find the page you're looking for.</h1>
-          <p>Head on back to the <stencil-route-link url="/ionicons" exact={true} class="block">Icons page</stencil-route-link>.</p>
+          <p>Head back to the <stencil-route-link url="/ionicons" exact={true} class="block">Icons</stencil-route-link>.</p>
         </ResponsiveContainer>
 
         <footer-bar></footer-bar>

--- a/src/components/notfound-page/notfound-page.tsx
+++ b/src/components/notfound-page/notfound-page.tsx
@@ -12,7 +12,7 @@ export class NotFoundPage {
       <main>
         <ResponsiveContainer>
           <h1>Oops! We can't find the page you're looking for.</h1>
-          <p>Head back to the <stencil-route-link url="/ionicons" exact={true} class="block">Icons</stencil-route-link>.</p>
+          <p>Take me back to the <stencil-route-link url="/ionicons" exact={true} class="block">Icons</stencil-route-link>.</p>
         </ResponsiveContainer>
 
         <footer-bar></footer-bar>

--- a/src/components/notfound-page/notfound-page.tsx
+++ b/src/components/notfound-page/notfound-page.tsx
@@ -11,8 +11,8 @@ export class NotFoundPage {
     return (
       <main>
         <ResponsiveContainer>
-          <h1>Woops! We can't find the page your looking for.</h1>
-          <p>Head on back to the <stencil-route-link url="/" class="block">Icons page</stencil-route-link>.</p>
+          <h1>Oops! We can't find the page you're looking for.</h1>
+          <p>Head on back to the <stencil-route-link url="/ionicons" exact={true} class="block">Icons page</stencil-route-link>.</p>
         </ResponsiveContainer>
 
         <footer-bar></footer-bar>

--- a/vercel.json
+++ b/vercel.json
@@ -2,7 +2,7 @@
   "rewrites": [
     {
       "source": "/",
-      "destination": "/ionicons/"
+      "destination": "/ionicons"
     }
   ]
 }

--- a/vercel.json
+++ b/vercel.json
@@ -1,5 +1,5 @@
 {
-  "rewrites": [
+  "redirects": [
     {
       "source": "/",
       "destination": "/ionicons"

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,8 @@
+{
+  "rewrites": [
+    {
+      "source": "/",
+      "destination": "/ionicons/"
+    }
+  ]
+}


### PR DESCRIPTION
Test this out by going to the following URL: https://ionicons-site-git-chore-redirect-ionic1.vercel.app/

and seeing it redirects to: https://ionicons-site-git-chore-redirect-ionic1.vercel.app/ionicons

Alternatively if you go here you will see it does not redirect: https://ionicons-site.vercel.app/

I don't think this will affect the main site but I wanted to be sure so added reviewers