### PR TITLE
fix: clicking code container copies to clipboard

### DIFF
--- a/src/components/toast-bar/toast-bar.tsx
+++ b/src/components/toast-bar/toast-bar.tsx
@@ -137,8 +137,8 @@ export class ToastBar {
                     </stencil-route-link>
                   </div>
 
-                  <code>
-                    <span class="hover-highlight" onClick={() => this.handleCodeClick(iconAttrName)}>
+                  <code onClick={() => this.handleCodeClick(iconAttrName)}>
+                    <span class="hover-highlight">
                       {'<'}<span class="yellow">ion-icon</span>&nbsp;<span class="orange">name</span>{'='}<span class="green">{`"${iconAttrName}"`}</span>{'>'}{'</'}<span class="yellow">ion-icon</span>{'>'}
                     </span>
                   </code>

--- a/src/index.html
+++ b/src/index.html
@@ -147,7 +147,7 @@
 
     <ionicons-site></ionicons-site>
 
-    <svg data-ionicons="7.1.0" style="display:none">
+    <svg data-ionicons="7.1.2" style="display:none">
 <style>
 .ionicon {
   fill: currentColor;


### PR DESCRIPTION
Closes #36 

Clicking the padded space of the code container, which shows the code highlighted, will now copy the contents to the clipboard when clicked. 