### PR TITLE
docs(usage): add browser support table

### DIFF
--- a/src/components/usage-page/content.tsx
+++ b/src/components/usage-page/content.tsx
@@ -156,6 +156,49 @@ export default function (version: string, name = "heart", suffix = "") {
 </ion-button>`
       )}
 
+      <h2>Browser support</h2>
+      <p>Ionicons are supported on the browsers listed below:</p>
+      <table>
+        <thead>
+          <tr>
+            <th>Browser</th>
+            <th>Version</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>
+              <strong>Chrome</strong>
+            </td>
+            <td>79+</td>
+          </tr>
+          <tr>
+            <td>
+              <strong>Safari</strong>
+            </td>
+            <td>14+</td>
+          </tr>
+          <tr>
+            <td>
+              <strong>Edge</strong>
+            </td>
+            <td>79+</td>
+          </tr>
+          <tr>
+            <td>
+              <strong>Firefox</strong>
+            </td>
+            <td>70+</td>
+          </tr>
+          <tr>
+            <td>
+              <strong>IE 11</strong>
+            </td>
+            <td>Not supported</td>
+          </tr>
+        </tbody>
+      </table>
+
       <h2>Migrating from v4</h2>
       <p>
         See the{" "}

--- a/src/components/usage-page/content.tsx
+++ b/src/components/usage-page/content.tsx
@@ -157,7 +157,6 @@ export default function (version: string, name = "heart", suffix = "") {
       )}
 
       <h2>Browser support</h2>
-      <p>Ionicons are supported on the browsers listed below:</p>
       <table>
         <caption>Supported browsers</caption>
         <thead>
@@ -199,6 +198,7 @@ export default function (version: string, name = "heart", suffix = "") {
           </tr>
         </tbody>
       </table>
+      <p>Report problems with this compatibility data on <a href="https://github.com/ionic-team/ionicons/issues" target="_blank">GitHub</a></p>
 
       <h2>Migrating from v4</h2>
       <p>

--- a/src/components/usage-page/content.tsx
+++ b/src/components/usage-page/content.tsx
@@ -157,6 +157,7 @@ export default function (version: string, name = "heart", suffix = "") {
       )}
 
       <h2>Browser support</h2>
+      <p>Report problems with this compatibility data on <a href="https://github.com/ionic-team/ionicons/issues" target="_blank">GitHub</a>.</p>
       <table>
         <caption>Supported browsers</caption>
         <thead>
@@ -198,7 +199,6 @@ export default function (version: string, name = "heart", suffix = "") {
           </tr>
         </tbody>
       </table>
-      <p>Report problems with this compatibility data on <a href="https://github.com/ionic-team/ionicons/issues" target="_blank">GitHub</a></p>
 
       <h2>Migrating from v4</h2>
       <p>

--- a/src/components/usage-page/content.tsx
+++ b/src/components/usage-page/content.tsx
@@ -159,6 +159,7 @@ export default function (version: string, name = "heart", suffix = "") {
       <h2>Browser support</h2>
       <p>Ionicons are supported on the browsers listed below:</p>
       <table>
+        <caption>Supported browsers</caption>
         <thead>
           <tr>
             <th>Browser</th>

--- a/src/components/usage-page/usage-page.scss
+++ b/src/components/usage-page/usage-page.scss
@@ -8,4 +8,21 @@ usage-page {
   .lead {
     color: #6e7f99;
   }
+
+  --browser-table-border-color: var(--color-heather);
+
+  table {
+    border-collapse: collapse;
+    border-radius: 8px;
+    border-style: hidden;
+    box-shadow: inset 0 0 0 1px var(--browser-table-border-color);
+  }
+
+  th,
+  td {
+    border: 1px solid var(--browser-table-border-color);
+    line-height: 1.6;
+    padding: 0.75rem;
+    text-align: center;
+  }
 }


### PR DESCRIPTION
We decided to make the support the same as Ionic v7. I did some basic styling on the table to make it look similar to the one from the [Framework docs](https://ionicframework.com/docs/reference/browser-support#desktop-browsers), but kept it simple instead of trying to match it exactly.

[Vercel build](https://ionicons-site-git-fw-4947-ionic1.vercel.app/ionicons/usage#:~:text=ion%2Dbutton%3E-,Browser%20support,-Ionicons%20are%20supported)