### PR TITLE
chore: prepare for node v20 bump

### DIFF
--- a/src/components/ionicons-site/ionicons-site.tsx
+++ b/src/components/ionicons-site/ionicons-site.tsx
@@ -1,4 +1,4 @@
-import { Component, Listen, State, h } from "@stencil/core";
+import { Component, Listen, State, h, Build } from "@stencil/core";
 import "@stencil/router";
 
 interface IconData {
@@ -44,6 +44,8 @@ export class IoniconsSite {
   }
 
   async loadData() {
+    if (Build.isServer) return;
+
     const res = await fetch("/ionicons/ionicons.json");
     const json = await res.json();
 


### PR DESCRIPTION
This PR:

- addresses fetch changes implemented in nodejs v18 that require a build time check