### PR TITLE
feat: release v8.0.13

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "archiver": "^4.0.1",
     "fs-extra": "^9.0.1",
     "highlight.js": "^10.1.1",
-    "ionicons": "^7.1.0",
+    "ionicons": "^8.0.13",
     "prismic-dom": "^2.2.3",
     "prismic-javascript": "^2.7.1"
   },


### PR DESCRIPTION
Fixes #53 

Please can we finally update this site!

I just came back to the issue again and found my own request for updating the badge from two years ago.

There have been two abandoned pr attempts to update this over the years, and I've just investigated it myself and its so simple to do.

You did all the hard work back in the day, the site generates everything based on the current npm package version.

I've looked at the documentation and it auto updates with the references and is still relevant from what I can see.

There have been no real front end changes since the last published site version (7.x), no breaking changes to note in the docs page.

The issues two prs ago about some icons not appearing were resolved with the modernisation pr on the main repo.

It even generates the downloadable zip files automatically.

Its just one package version in the package.json and redeploy it! 

Or if you haven't worked on this for ages and don't want to blindly accept it, then just pull the repo down, tweak the package version, do `npm i`, `npm start`, and you will see its all fully updated.

@brandyscarney I can see you are still doing most of the actual ionicon releases... do you want to step up and take this win? :)